### PR TITLE
Bug/readme link typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/chenglou/tween-functions"
+    "url": "https://github.com/chenglou/tween-functions"
   },
   "keywords": [
     "tween",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tween-functions",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Robert Penner's easing functions, slightly modified",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates:
- Github link which was causing 404s from npm
- Module version so that the change can be published to npm
